### PR TITLE
Undefined subroutine &JSON::decode_json called at line 244

### DIFF
--- a/FHEM/10_TASMOTA_DEVICE.pm
+++ b/FHEM/10_TASMOTA_DEVICE.pm
@@ -240,7 +240,7 @@ sub Decode($$$) {
     my $h;
 
     eval {
-        $h = JSON::decode_json($value);
+        $h = JSON::XS::decode_json($value);
         1;
     };
 


### PR DESCRIPTION
Bei mir wurden die Readnings nicht angelegt, als auch kamen meldungen ins fhem.log "...  - Undefined subroutine &JSON::decode_json called at ./FHEM/10_TASMOTA_DEVICE.pm line 244." 
Nach der Anpassung funktionierte der Aufruf der Subroutine.